### PR TITLE
Changes for execute function instead of double fetch

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 const routerCreation = require('./routerCreation.js')
-const queryObject = require('./wip.js')
+const queryMap = require('./wip.js')
 
 module.exports = {
     routerCreation,
-    queryObject
+    queryMap
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Rest API to GraphQL queries",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest --verbose"
   },
   "repository": {
     "type": "git",
@@ -32,8 +32,7 @@
   },
   "homepage": "https://github.com/oslabs-beta/MONARQ#readme",
   "dependencies": {
-    "express": "^4.17.1",
-    "node-fetch": "^2.6.1"
+    "express": "^4.17.1"
   },
   "devDependencies": {
     "jest": "^26.6.3"

--- a/routerCreation.js
+++ b/routerCreation.js
@@ -1,36 +1,47 @@
 const express = require('express');
+const fetch = require('node-fetch');
 
-
+//everything that errors out in routerCreationFunction should throw an error
 module.exports = routerCreation = (
-    endPointObject, //from the manifest file 
-    createdGQL //object that contains queries/mutations that were created with the previous function
+    manifest, //from the manifest file 
+    createdGQL, //object that contains queries/mutations that were created with the previous function
+    infoForExecution //object that will have three keys- schema, context and wrapper function that will execute the graphql query
 ) => {
 
     const router = express.Router();
 
-    //*MAY NEED TO UNSTRINGIFY THE MANIFEST JSON OBJECT WHEN IMPORTING *//
-    if (!endPointObject || !createdGQL) throw new Error('Arguments not passed in Correctly into routerCreation function')
+
+    let endPointObj = validateManifest(manifest)
 
 
-    const { endpoints } = endPointObject;
+    const { endpoints } = endPointObj;
 
     Object.keys(endpoints).forEach(apiPath => {
 
         Object.keys(endpoints[apiPath]).forEach(method => {
-
+            let { queries, args } = createdGQL;
+            const { defaultParams } = endpoints[apiPath][method];
             let currentQuery;
+            
+            args = args[endpoints[apiPath][method].operation]
 
-            for (let query in createdGQL) {
+            for (let query in queries) {
                 if (query === endpoints[apiPath][method].operation) {
-                    currentQuery = createdGQL[query]
+                    currentQuery = queries[query]
                 }
             }
+
+            if (!currentQuery) throw new Error('Manifest Obj \'s Operation Field Doesn\'t match Valid Query or Mutation in Schema. Operation Field is Mandatory in Manifest Obj for every method. Check the operation field in the Manifest Object. Visit our website to create a manifest object')
+
 
             addRoutes(
                 method,
                 apiPath,
                 currentQuery,
-                router
+                router,
+                args,
+                defaultParams,
+                infoForExecution
             );
 
         });
@@ -46,11 +57,46 @@ module.exports = routerCreation = (
 /////                       /////
 /////////////////////////////////
 
+const validateManifest  = manifestObj => {
+    if (Object.keys(manifestObj.endpoints).length < 1) throw new Error('manifest is not defined in routeCreation function. Please check documentation for MONARQ on how to pass in the manifest properly');
+
+    return manifestObj;
+}
+
+const populateVariables = (requiredVariables, defaultParams, reqObj) => {
+    if (!requiredVariables) return;
+
+    let variables = {};
+
+    
+    Object.keys(requiredVariables).forEach(key => {
+        Object.keys(reqObj).forEach(keyMatch => {
+            // console.log('KEY: ', key)
+            // console.log('keyMatch: ', keyMatch)
+            if (key === `$${keyMatch}`){
+                variables[keyMatch] = reqObj[keyMatch]
+            }
+        })
+    })
+
+    //console.log('VARIABLES: ', variables)
+    return Object.keys(variables).length > 0 ? variables: defaultParams ? defaultParams : null;
+}
+
+
+/* Everything in addRoutes function should:
+    a) send response status and message to client
+    b) warm in the console the error that is returned from graphql
+*/
+
 const addRoutes = (
     method,
     apiPath,
     GQLquery,
-    router
+    router,
+    argsForQuery,
+    defaultParams,
+    infoForExecution
 ) => {
 
     switch (method.toLowerCase()) {
@@ -58,25 +104,49 @@ const addRoutes = (
             router.get(apiPath, async (req, res) => {
 
                 const { query, params, body } = req;
-                //can add addition error logic/security here
-                const variables = {
+
+                //order does matter, if query has the same key name in params or body, it will be overwritten when params or body is spread
+                const possibleInputs = {
                     ...query,
                     ...params,
                     ...body
                 };
+                
+                const { schema, context, executeFn } = infoForExecution;
+                const variables = populateVariables(argsForQuery, defaultParams, possibleInputs);
+                
 
-                fetch('http://localhost:3000/graphql', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({
-                        query: GQLquery,
-                        variables: variables
-                    })
-                }).then(data => data.json()).then(responseGQL => {
-                    res.locals.response = responseGQL;
-                    return res.status(200).json(res.locals.response)
-                }).catch(err => console.log(err));
+              //checking if context is a function or and object and adding the headers to that object
+                let newContext;
 
+                if (typeof context === 'function') {
+                    newContext = await context();
+                    newContext.headers = req.headers
+                }  else if (context === 'object') {
+                    newContext.headers = req.headers
+                }
+
+                if (!newContext) throw new Error('Context was not passed in correctly, could not execute the query. Make sure context is either a function or an object. Please check the documentation for MONARQ further understanding.')
+
+                const executeObj = {
+                    query: GQLquery,
+                    variables: variables,
+                    schema,
+                    context: newContext
+                }
+
+                const response = await executeFn(executeObj)
+                
+
+                if (response.errors) {
+                    res.status(500).json('Issue Executing Request, Please Check Documentation on How to send Request to Server')
+                    console.warn(`${response.errors}`)
+                    return;
+                }
+
+                res.locals.data = response;
+
+                return res.status(200).json(res.locals.data)
             })
 
             break;
@@ -86,25 +156,49 @@ const addRoutes = (
             router.delete(apiPath, async (req, res) => {
 
                 const { query, params, body } = req;
-                //can add addition error logic/security here
-                const variables = {
+
+                //order does matter, if query has the same key name in params or body, it will be overwritten when params or body is spread
+                const possibleInputs = {
                     ...query,
                     ...params,
                     ...body
                 };
+                
+                const { schema, context, executeFn } = infoForExecution;
+                const variables = populateVariables(argsForQuery, defaultParams, possibleInputs);
+                
 
-                fetch('http://localhost:3000/graphql', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({
-                        query: GQLquery,
-                        variables: variables
-                    })
-                }).then(data => data.json()).then(responseGQL => {
-                    res.locals.response = responseGQL;
-                    return res.status(200).json(res.locals.response)
-                }).catch(err => console.log(err))
+              //checking if context is a function or and object and adding the headers to that object
+                let newContext;
 
+                if (typeof context === 'function') {
+                    newContext = await context();
+                    newContext.headers = req.headers
+                }  else if (context === 'object') {
+                    newContext.headers = req.headers
+                }
+
+                if (!newContext) throw new Error('Context was not passed in correctly, could not execute the query. Make sure context is either a function or an object. Please check the documentation for MONARQ further understanding.')
+
+                const executeObj = {
+                    query: GQLquery,
+                    variables: variables,
+                    schema,
+                    context: newContext
+                }
+
+                const response = await executeFn(executeObj)
+                
+
+                if (response.errors) {
+                    res.status(500).json('Issue Executing Request, Please Check Documentation on How to send Request to Server')
+                    console.warn(`${response.errors}`)
+                    return;
+                }
+
+                res.locals.data = response;
+
+                return res.status(200).json(res.locals.data)
             });
 
             break;
@@ -114,25 +208,49 @@ const addRoutes = (
             router.post(apiPath, async (req, res) => {
 
                 const { query, params, body } = req;
-                //can add addition error logic/security here
-                const variables = {
+
+                //order does matter, if query has the same key name in params or body, it will be overwritten when params or body is spread
+                const possibleInputs = {
                     ...query,
                     ...params,
                     ...body
+                };
+                
+                const { schema, context, executeFn } = infoForExecution;
+                const variables = populateVariables(argsForQuery, defaultParams, possibleInputs);
+                
+
+              //checking if context is a function or and object and adding the headers to that object
+                let newContext;
+
+                if (typeof context === 'function') {
+                    newContext = await context();
+                    newContext.headers = req.headers
+                }  else if (context === 'object') {
+                    newContext.headers = req.headers
                 }
 
-                fetch('http://localhost:3000/graphql', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({
-                        query: GQLquery,
-                        variables: variables
-                    })
-                }).then(data => data.json()).then(responseGQL => {
-                    res.locals.response = responseGQL;
-                    return res.status(200).json(res.locals.response)
-                }).catch(err => console.log(err))
+                if (!newContext) throw new Error('Context was not passed in correctly, could not execute the query. Make sure context is either a function or an object. Please check the documentation for MONARQ further understanding.')
 
+                const executeObj = {
+                    query: GQLquery,
+                    variables: variables,
+                    schema,
+                    context: newContext
+                }
+
+                const response = await executeFn(executeObj)
+                
+
+                if (response.errors) {
+                    res.status(500).json('Issue Executing Request, Please Check Documentation on How to send Request to Server')
+                    console.warn(`${response.errors}`)
+                    return;
+                }
+
+                res.locals.data = response;
+
+                return res.status(200).json(res.locals.data)
             });
 
             break;
@@ -142,24 +260,49 @@ const addRoutes = (
             router.put(apiPath, async (req, res) => {
 
                 const { query, params, body } = req;
-                //can add addition error logic/security here
-                const variables = {
+
+                //order does matter, if query has the same key name in params or body, it will be overwritten when params or body is spread
+                const possibleInputs = {
                     ...query,
                     ...params,
                     ...body
+                };
+                
+                const { schema, context, executeFn } = infoForExecution;
+                const variables = populateVariables(argsForQuery, defaultParams, possibleInputs);
+                
+
+              //checking if context is a function or and object and adding the headers to that object
+                let newContext;
+
+                if (typeof context === 'function') {
+                    newContext = await context();
+                    newContext.headers = req.headers
+                }  else if (context === 'object') {
+                    newContext.headers = req.headers
                 }
 
-                fetch('http://localhost:3000/graphql', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({
-                        query: GQLquery,
-                        variables: variables
-                    })
-                }).then(data => data.json()).then(responseGQL => {
-                    res.locals.response = responseGQL;
-                    return res.status(200).json(res.locals.response)
-                }).catch(err => console.log(err))
+                if (!newContext) throw new Error('Context was not passed in correctly, could not execute the query. Make sure context is either a function or an object. Please check the documentation for MONARQ further understanding.')
+
+                const executeObj = {
+                    query: GQLquery,
+                    variables: variables,
+                    schema,
+                    context: newContext
+                }
+
+                const response = await executeFn(executeObj)
+                
+
+                if (response.errors) {
+                    res.status(500).json('Issue Executing Request, Please Check Documentation on How to send Request to Server')
+                    console.warn(`${response.errors}`)
+                    return;
+                }
+
+                res.locals.data = response;
+
+                return res.status(200).json(res.locals.data)
 
             });
 
@@ -170,31 +313,56 @@ const addRoutes = (
             router.patch(apiPath, async (req, res) => {
 
                 const { query, params, body } = req;
-                //can add addition error logic/security here
-                const variables = {
+
+                //order does matter, if query has the same key name in params or body, it will be overwritten when params or body is spread
+                const possibleInputs = {
                     ...query,
                     ...params,
                     ...body
+                };
+                
+                const { schema, context, executeFn } = infoForExecution;
+                const variables = populateVariables(argsForQuery, defaultParams, possibleInputs);
+                
+
+              //checking if context is a function or and object and adding the headers to that object
+                let newContext;
+
+                if (typeof context === 'function') {
+                    newContext = await context();
+                    newContext.headers = req.headers
+                }  else if (context === 'object') {
+                    newContext.headers = req.headers
                 }
 
-                fetch('http://localhost:3000/graphql', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({
-                        query: GQLquery,
-                        variables: variables
-                    })
-                }).then(data => data.json()).then(responseGQL => {
-                    res.locals.response = responseGQL;
-                    return res.status(200).json(res.locals.response)
-                }).catch(err => console.log(err))
+                if (!newContext) throw new Error('Context was not passed in correctly, could not execute the query. Make sure context is either a function or an object. Please check the documentation for MONARQ further understanding.')
+
+                const executeObj = {
+                    query: GQLquery,
+                    variables: variables,
+                    schema,
+                    context: newContext
+                }
+
+                const response = await executeFn(executeObj)
+                
+
+                if (response.errors) {
+                    res.status(500).json('Issue Executing Request, Please Check Documentation on How to send Request to Server')
+                    console.warn(`${response.errors}`)
+                    return;
+                }
+
+                res.locals.data = response;
+
+                return res.status(200).json(res.locals.data)
 
             });
 
             break;
         }
 
-        default: throw new Error('Operation Doesn\'t match the HTTP Methods allowed for this NPM Package, Please see documentation on which HTTP Methods are allowed and/or check the Manifest Object');
+        default: throw new Error('Operation Doesn\'t match the HTTP Methods allowed for this NPM Package, Please see documentation on which HTTP Methods are allowed and/or check the Manifest Object\'s Method Object');
     }
 }
 

--- a/wip.js
+++ b/wip.js
@@ -1,8 +1,3 @@
-// note: was not able to use the import syntax, but the const + require language did work
-// import { graphql, buildSchema, makeExecutableSchema } from 'graphql'
-// const graphql = require('graphql');
-// const path = require('path');
-// const fs = require('fs');
 
 // user will designate REST endpoints, but assumption is that a GQL operation already exists for each one
 // error handling - if an invalid/non-existent operation is specified
@@ -25,21 +20,33 @@ const scalarTypes = ['String', 'Int', 'ID', 'Boolean', 'Float', ...customScalars
 
 
 
-/************************************************* 
-***** FINAL QUERY OBJECT OUTPUT FUNCTION *********
-**************************************************/
+/******************************************************** 
+***** FINAL ARGS & QUERY OBJECT OUTPUT FUNCTION *********
+*********************************************************/
 
-function queryObject(manifest, schema) {
+function queryMap(manifest, schema) {
   const endPoints = manifest.endpoints;
-  let returnObj = {};
+  const argsObj = {};
+  const queryObj = {};
   for (const path in endPoints) {
     for (const action in endPoints[path]) {
       const operationName = endPoints[path][action].operation
-      returnObj[operationName] = generateQuery(schema, operationName);
+      
+      // generate the args object
+      const typeSchema = typeChecker(schema, operationName)[1]
+      const operationFields = typeSchema[operationName];
+      const varObj = grabArgs(schema, operationFields.args)[1];
+      argsObj[operationName] = varObj
+
+      // generate the query object
+      queryObj[operationName] = generateQuery(schema, operationName);
     };
   };
-  return returnObj;
-}
+  return {
+    args: argsObj,
+    queries: queryObj
+  };
+};
 
 
 
@@ -49,18 +56,9 @@ function queryObject(manifest, schema) {
 
 function generateQuery(schema, operation) {
   // first figure out whether it is a query or mutation
-  let operationType;
-  let typeSchema;
-  const querySchema = schema.getQueryType().getFields();
-  const mutationSchema = schema.getMutationType().getFields();
-  if (Object.keys(querySchema).includes(operation)) {
-    operationType = 'Query';
-    typeSchema = querySchema;
-  };
-  if (Object.keys(mutationSchema).includes(operation)) {
-    operationType = 'Mutation';
-    typeSchema = mutationSchema;
-  };
+  const typeInfo = typeChecker(schema, operation)
+  const operationType = typeInfo[0];
+  const typeSchema = typeInfo[1];
 
   // now look for all of the fields that need to be specified for the operation
   let returnFields = {};
@@ -111,6 +109,26 @@ function generateQuery(schema, operation) {
 /************************** 
 ***** HELPER FUNCTIONS ****
 ***************************/
+
+/* checks whether the operation is a query or mutation and returns that */
+function typeChecker(schema, operation) {
+  let operationType;
+  let typeSchema;
+  const querySchema = schema.getQueryType().getFields();
+  const mutationSchema = schema.getMutationType().getFields();
+  if (Object.keys(querySchema).includes(operation)) {
+    operationType = 'Query';
+    typeSchema = querySchema;
+  };
+  if (Object.keys(mutationSchema).includes(operation)) {
+    operationType = 'Mutation';
+    typeSchema = mutationSchema;
+  };
+  if (!operationType) throw new Error(`Operation '${operation}' is not defined in the schema`)
+  return [operationType, typeSchema];
+}
+
+
 
 /* converts custom type text to simple strings (removes [] and !) */
 function typeTrim(type) {
@@ -233,8 +251,8 @@ function varStrBuild(varObj) {
 
 
 
-//export default queryObject;
-module.exports = queryObject;
+module.exports = queryMap;
+
 
 
 


### PR DESCRIPTION
Now the User must:

- Define a wrapper function that takes an object with 4 keys (query, variables, context, schema) and inside the wrapper function it will return the execution of the graphql query with a response
- pass as arguments into the routerCreation function: manifest, queryObj, {context, schema, executeFn}